### PR TITLE
A couple of small fixes to get the configure.sh working.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### macOS Configuration
 Run the following to configure macOS from scratch...
 ```
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/jldeen/dotfiles/mac/configure.sh)"
+bash <(curl -fsSL https://raw.githubusercontent.com/jldeen/dotfiles/mac/configure.sh)
 ```
 
 It should go without saying, you should never run a script on your system without reading it to understand what changes it will make to your system. My scripts and code samples are no exception to the rule.

--- a/configure.sh
+++ b/configure.sh
@@ -115,7 +115,7 @@ pl10kInstall () {
         info 'powerlevel10k already installed'
     else
         echo "Now installing powerlevel10k..."
-        git clone https://github.com/romkatv/powerlevel10k.git $ZSH_CUSTOM/themes/powerlevel10k && success 'powerlevel10k installed'
+        git clone https://github.com/romkatv/powerlevel10k.git ~/.oh-my-zsh/custom/themes/powerlevel10k && success 'powerlevel10k installed'
     fi
 }
 

--- a/configure.sh
+++ b/configure.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eou pipefail
 
-source <curl -fsSL https://raw.githubusercontent.com/aaroncoville/dotfiles/mac/script/prompt )
+source /dev/stdin <<< "$(curl -fsSL https://raw.githubusercontent.com/aaroncoville/dotfiles-1/mac/script/prompt)"
 
 brewInstall () {
     # Install brew

--- a/configure.sh
+++ b/configure.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eou pipefail
 
-source /dev/stdin <<< "$(curl -fsSL https://raw.githubusercontent.com/aaroncoville/dotfiles-1/mac/script/prompt)"
+source /dev/stdin <<< "$(curl -fsSL https://raw.githubusercontent.com/jldeen/dotfiles/mac/script/prompt)"
 
 brewInstall () {
     # Install brew
@@ -95,7 +95,7 @@ ohmyzshPluginInstall () {
     if [ -d "$HOME/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting" ]; then
         info 'zsh-syntax-highlighting already installed'
     else
-        git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ~/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting && 'zsh-syntax-highlighting installed'
+        git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ~/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting && success 'zsh-syntax-highlighting installed'
     fi
 }
 

--- a/configure.sh
+++ b/configure.sh
@@ -186,11 +186,11 @@ brewUpdate
 
 # zsh setup
 zshInstall
-zshZInstall
 configureGitCompletion
 
 # oh my zsh setup
 ohmyzshInstall
+zshZInstall
 ohmyzshPluginInstall
 pl9kInstall
 pl10kInstall

--- a/configure.sh
+++ b/configure.sh
@@ -75,7 +75,7 @@ ohmyzshInstall () {
     else
     echo "oh-my-zsh not found, now installing oh-my-zsh..."
     echo ''
-    sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+    sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" "" --unattended
     success 'oh-my-zsh installed'
     fi
 }

--- a/configure.sh
+++ b/configure.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eou pipefail
 
-source ./script/prompt
+source <curl -fsSL https://raw.githubusercontent.com/aaroncoville/dotfiles/mac/script/prompt )
 
 brewInstall () {
     # Install brew

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -264,7 +264,7 @@ jdFontSetup () {
 
 jdconfigFix () {
   # .config permissions fix
-  if [ -d "$HOME/.config" ]; then
+  if [ ! -d "$HOME/.config" ]; then
     info "$HOME/.config doesn't exist, nothing to fix"
   else
     sudo chown $(whoami) $HOME/.config 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -258,7 +258,7 @@ jditermConfig () {
 
 jdFontSetup () {
   # install Source Code Pro nerd font
-  cp $HOME/.dotfiles/Source\ Code\ Pro\ Nerd\ Font\ Complete.ttf /Library/Fonts
+  sudo cp $HOME/.dotfiles/Source\ Code\ Pro\ Nerd\ Font\ Complete.ttf /Library/Fonts
   success "Source Code Pro font copied successfully!"
 }
 


### PR DESCRIPTION
First, thanks for all of the awesome work! I hope these proposed changes help out even a little.

Fix for #21 - updates the source to use the remote prompt file, updates the execution command in the README.md

I moved zshZInstall after ohmyzshInstall as zshZInstall created the .oh-my-zsh directory giving a false positive when checking if oh-my-zsh is already installed.

The success call for logging output was missing on the zsh-syntax-highlighting cloning line causing an error.

This fixes the first few gotchas I had when working my fork of your repository.

Right now, when doing a fresh install on macOS ohmyzsh immediately loads into the terminal stopping script execution. I'm not sure how to get around this yet, right now if you are doing a fresh install you have to run the script and then run it again after ohmyzsh takes over your terminal. File this under known issues for now.
