### PR TITLE
fix syntax error in setup_ruby function

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -54,7 +54,7 @@ setup_ruby () {
     read -p "Do you want to install and configure Ruby" yn
     case $yn in
         [Yy]* ) installRuby; break;;
-        [Nn]* ) echo "Not installing ruby..."
+        [Nn]* ) echo "Not installing ruby...";break;;
         * ) echo "Please answer yes or no.";;
     esac
 done


### PR DESCRIPTION
This fixes the following syntax error when running the configure script and opting to use jldeen's dotfile.

`./bootstrap: line 58: syntax error near unexpected token )'`